### PR TITLE
add --args

### DIFF
--- a/src/nxlink.c
+++ b/src/nxlink.c
@@ -448,11 +448,6 @@ int add_extra_args(int len, char *buf, char *extra_args) {
 
 	int extra_len = strlen(extra_args);
 
-	if (extra_len >= 2 && extra_args[0] == '"' && extra_args[extra_len-1] == '"') {
-		extra_len -= 2;
-		extra_args += 1;
-	}
-
 	char *dst = &buf[len];
 	char *src = extra_args;
 

--- a/src/nxlink.c
+++ b/src/nxlink.c
@@ -448,7 +448,7 @@ int add_extra_args(int len, char *buf, char *extra_args) {
 
 	int extra_len = strlen(extra_args);
 
-	if (extra_len >= 2 && extra_args[0] == '"' && extra_args[extra_len-1] == '"' ) {
+	if (extra_len >= 2 && extra_args[0] == '"' && extra_args[extra_len-1] == '"') {
 		extra_len -= 2;
 		extra_args += 1;
 	}
@@ -462,15 +462,15 @@ int add_extra_args(int len, char *buf, char *extra_args) {
 		do {
 			c = *src++;
 			extra_len--;
-		} while ( c ==' ' && extra_len >= 0);
+		} while(c ==' ' && extra_len >= 0);
 
-		if ( c == '\"' || c == '\'') {
+		if (c == '\"' || c == '\'') {
 			int quote = c;
 			do {
 				c = *src++;
 				if (c != quote) *dst++ = c;
 				extra_len--;
-			} while (c != quote && extra_len >= 0);
+			} while(c != quote && extra_len >= 0);
 
 			*dst++ = '\0';
 
@@ -480,10 +480,10 @@ int add_extra_args(int len, char *buf, char *extra_args) {
 			*dst++ = c;
 			extra_len--;
 			c = *src++;
-		} while( c != ' ' && extra_len >= 0);
+		} while(c != ' ' && extra_len >= 0);
 
 		*dst++ = '\0';
-	} while (extra_len >= 0 );
+	} while(extra_len >= 0);
 
 	return dst - buf;
 }

--- a/src/nxlink.c
+++ b/src/nxlink.c
@@ -464,6 +464,18 @@ int add_extra_args(int len, char *buf, char *extra_args) {
 			extra_len--;
 		} while ( c ==' ' && extra_len >= 0);
 
+		if ( c == '\"' || c == '\'') {
+			int quote = c;
+			do {
+				c = *src++;
+				if (c != quote) *dst++ = c;
+				extra_len--;
+			} while (c != quote && extra_len >= 0);
+
+			*dst++ = '\0';
+
+			continue;
+		}
 		do {
 			*dst++ = c;
 			extra_len--;
@@ -471,7 +483,7 @@ int add_extra_args(int len, char *buf, char *extra_args) {
 		} while( c != ' ' && extra_len >= 0);
 
 		*dst++ = '\0';
-	} while (extra_len > 0 );
+	} while (extra_len >= 0 );
 
 	return dst - buf;
 }


### PR DESCRIPTION
allows gathering of arguments to be sent to the nro and avoid attempted parsing by nxlink. This allows arguments starting with - and -- to be passed to the nro without getopt complaining.