### PR TITLE
Don't use duplicate keysin the NPDM-json format

### DIFF
--- a/src/elf2kip.c
+++ b/src/elf2kip.c
@@ -315,74 +315,112 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
                     kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 5) | (0x000F));
                 }
             }
-        } else if (!strcmp(type_str, "map")) {
-            if (cur_cap + 2 > 0x20) {
-                fprintf(stderr, "Error: Too many capabilities!\n");
+        } else if (!strcmp(type_str, "maps")) {
+            if (!cJSON_IsArray(value)) {
+                fprintf(stderr, "Maps Capability value must be array!\n");
                 status = 0;
                 goto PARSE_CAPS_END;
             }
-            if (!cJSON_IsObject(value)) {
-                fprintf(stderr, "Map Capability value must be object!\n");
+            const cJSON *cur_map = NULL;
+            cJSON_ArrayForEach(cur_map, value) {
+                if (cur_cap + 2 > 0x20) {
+                    fprintf(stderr, "Error: Too many capabilities!\n");
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
+                if (!cJSON_IsObject(cur_map)) {
+                    fprintf(stderr, "Maps Capability content value must be object!\n");
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
+
+                u64 map_address = 0;
+                u64 map_size = 0;
+                int is_ro;
+                int is_io;
+                if (!cJSON_GetU64(cur_map, "address", &map_address) ||
+                    !cJSON_GetU64(cur_map, "size", &map_size) ||
+                    !cJSON_GetBoolean(cur_map, "is_ro", &is_ro) ||
+                    !cJSON_GetBoolean(cur_map, "is_io", &is_io)) {
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
+                desc = (u32)((map_address >> 12) & 0x00FFFFFFULL);
+                desc |= is_ro << 24;
+                kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 7) | (0x003F));
+
+                desc = (u32)((map_size >> 12) & 0x00FFFFFFULL);
+                is_io ^= 1;
+                desc |= is_io << 24;
+                kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 7) | (0x003F));
+            }
+        } else if (!strcmp(type_str, "map_pages")) {
+            if (!cJSON_IsArray(value)) {
+                fprintf(stderr, "Map Pages Capability value must be array!\n");
                 status = 0;
                 goto PARSE_CAPS_END;
             }
-            u64 map_address = 0;
-            u64 map_size = 0;
-            int is_ro;
-            int is_io;
-            if (!cJSON_GetU64(value, "address", &map_address) ||
-                !cJSON_GetU64(value, "size", &map_size) ||
-                !cJSON_GetBoolean(value, "is_ro", &is_ro) ||
-                !cJSON_GetBoolean(value, "is_io", &is_io)) {
-                status = 0;
-                goto PARSE_CAPS_END;
+            const cJSON *cur_map_page = NULL;
+            cJSON_ArrayForEach(cur_map_page, value) {
+                if (cur_cap + 1 > 0x20) {
+                    fprintf(stderr, "Error: Too many capabilities!\n");
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
+                u64 page_address = 0;
+                if (!cJSON_GetU64FromObjectValue(cur_map_page, &page_address)) {
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
+                desc = (u32)((page_address >> 12) & 0x00FFFFFFULL);
+                kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 8) | (0x007F));
             }
-            desc = (u32)((map_address >> 12) & 0x00FFFFFFULL);
-            desc |= is_ro << 24;
-            kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 7) | (0x003F));
-            
-            desc = (u32)((map_size >> 12) & 0x00FFFFFFULL);
-            is_io ^= 1;
-            desc |= is_io << 24;
-            kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 7) | (0x003F));
-        } else if (!strcmp(type_str, "map_page")) {
-            if (cur_cap + 1 > 0x20) {
-                fprintf(stderr, "Error: Too many capabilities!\n");
-                status = 0;
-                goto PARSE_CAPS_END;
-            }
-            u64 page_address = 0;
-            if (!cJSON_GetU64FromObjectValue(value, &page_address)) {
-                status = 0;
-                goto PARSE_CAPS_END;
-            }
-            desc = (u32)((page_address >> 12) & 0x00FFFFFFULL);
-            kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 8) | (0x007F));
-        } else if (!strcmp(type_str, "irq_pair")) {
-            if (cur_cap + 1 > 0x20) {
-                fprintf(stderr, "Error: Too many capabilities!\n");
-                status = 0;
-                goto PARSE_CAPS_END;
-            }
-            if (!cJSON_IsArray(value) || cJSON_GetArraySize(value) != 2) {
-                fprintf(stderr, "Error: IRQ Pairs must have size 2 array value.\n");
+        } else if (!strcmp(type_str, "irqs")) {
+            if (!cJSON_IsArray(value)) {
+                fprintf(stderr, "Error: IRQs must be in an array.\n");
                 status = 0;
                 goto PARSE_CAPS_END;
             }
             const cJSON *irq = NULL;
+            u16 lastirq = 0x400;
+            u16 curirq;
             cJSON_ArrayForEach(irq, value) {
-                desc <<= 10;
-                if (cJSON_IsNull(irq)) {
-                    desc |= 0x3FF;
-                } else if (cJSON_IsNumber(irq)) {
-                    desc |= ((u16)(irq->valueint)) & 0x3FF;
-                } else {
+                if (!cJSON_IsNumber(irq)) {
                     fprintf(stderr, "Failed to parse IRQ value.\n");
                     status = 0;
                     goto PARSE_CAPS_END;
                 }
+                curirq = (u16)irq->valueint;
+                if (curirq > 0x3FF) {
+                    fprintf(stderr, "IRQ should be between 0 and 0x3FF.\n");
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
+
+                if (lastirq == 0x400) {
+                    /* We have to handle irqs in pair. Remember the first of each pair */
+                    lastirq = curirq & 0x3FF;
+                } else if (cur_cap + 1 <= 0x20) {
+                    /* Once we have a pair, store it in the caps */
+                    desc = (lastirq << 10) | (curirq & 0x3FF);
+                    kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 12) | (0x07FF));
+                    desc = 0;
+                    lastirq = 0x400;
+                } else {
+                    fprintf(stderr, "Error: Too many capabilities!\n");
+                    status = 0;
+                    goto PARSE_CAPS_END;
+                }
             }
-            kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 12) | (0x07FF));
+            /* Handle last value in IRQ array. */
+            if (lastirq != 0x400 && cur_cap + 1 <= 0x20) {
+                desc = (lastirq << 10) | 0x3FF;
+                kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 12) | (0x07FF));
+            } else if (lastirq != 0x400) {
+                fprintf(stderr, "Error: Too many capabilities!\n");
+                status = 0;
+                goto PARSE_CAPS_END;
+            }
         } else if (!strcmp(type_str, "application_type")) {
             if (cur_cap + 1 > 0x20) {
                 fprintf(stderr, "Error: Too many capabilities!\n");

--- a/src/elf2kip.c
+++ b/src/elf2kip.c
@@ -445,6 +445,10 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
             }
             desc = (allow_debug & 1) | ((force_debug & 1) << 1);
             kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 17) | (0xFFFF));
+        } else {
+            fprintf(stderr, "Error: unknown capability %s\n", type_str);
+            status = 0;
+            goto PARSE_CAPS_END;
         }
     }
     
@@ -452,6 +456,7 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
         kip_hdr->Capabilities[i] = 0xFFFFFFFF;
     }
     
+    status = 1;
     PARSE_CAPS_END:
     cJSON_Delete(npdm_json);
     return status;
@@ -479,7 +484,10 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
     
-    ParseKipConfiguration(json, &kip_hdr);
+    if (!ParseKipConfiguration(json, &kip_hdr)) {
+        fprintf(stderr, "Failed to parse kip configuration!\n");
+        return EXIT_FAILURE;
+    }
 
     size_t elf_len;
     uint8_t* elf = ReadEntireFile(argv[1], &elf_len);


### PR DESCRIPTION
Currently, the NPDM-JSON format abuses duplicate keys where it should be using arrays instead. While cJSON supports this, most JSON parsers don't. This is causing issues for me currently when building [linkle](http://github.com/megatonhammer/linkle) as serde-json (a deserializer for JSON in rust) doesn't support this. While I could probably fix that issue in serde-json, I think moving to a saner format using JSON arrays is a better idea.

This PR will be accompanied by a fix in Atmosphere's boot_100.json/boot_200.json (which seem to be the only users of the offending keys), and a hactool fix.

(There's also an error handling fix in elf2kip snugged in here)

CC @SciresM 

Atmosphere PR: https://github.com/Atmosphere-NX/Atmosphere/pull/211
Hactool PR: Comes tomorrow.