### PR TITLE
Nacptool: fix bug with title id parsing on Windows.

### DIFF
--- a/src/nacptool.c
+++ b/src/nacptool.c
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
     int argi;
     u64 titleid=0;
     for (argi=6; argi<argc; argi++) {
-        if (strncmp(argv[argi], "--titleid=", 10)==0) sscanf(&argv[argi][10], "%016lX", &titleid);
+        if (strncmp(argv[argi], "--titleid=", 10)==0) sscanf(&argv[argi][10], "%016llX", &titleid);
     }
 
     for (i=0; i<12; i++) {//These are UTF-8.

--- a/src/nacptool.c
+++ b/src/nacptool.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <inttypes.h>
 
 typedef uint64_t u64;
 typedef uint32_t u32;
@@ -79,7 +80,7 @@ int main(int argc, char* argv[]) {
     int argi;
     u64 titleid=0;
     for (argi=6; argi<argc; argi++) {
-        if (strncmp(argv[argi], "--titleid=", 10)==0) sscanf(&argv[argi][10], "%016llX", &titleid);
+        if (strncmp(argv[argi], "--titleid=", 10)==0) sscanf(&argv[argi][10], "%016" SCNx64, &titleid);
     }
 
     for (i=0; i<12; i++) {//These are UTF-8.


### PR DESCRIPTION
On Windows, longs (as specified by %lX) are 32-bit, not 64-bit, so assuming its size results in the upper 32-bits of the title id being lost.

Appears to still work fine on Linux (tested on Antergos) and macOS.

`gcc` (this output is from clang, but it should also output with -Wall on gcc) also warns about this:

```
~/s/src> gcc nacptool.c
nacptool.c:82:89: warning: format specifies type 'unsigned long *' but the
      argument has type 'u64 *' (aka 'unsigned long long *') [-Wformat]
  ..."--titleid=", 10)==0) sscanf(&argv[argi][10], "%016lX", &titleid);
                                                    ~~~~~~   ^~~~~~~~
                                                    %16llX
1 warning generated.
```

Shoutout to @jakibaki for testing on macOS.