### PR TITLE
Stop using duplicate keys in JSON: take 2

### DIFF
--- a/src/elf2kip.c
+++ b/src/elf2kip.c
@@ -370,17 +370,18 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
                 goto PARSE_CAPS_END;
             }
             const cJSON *irq = NULL;
+            int desc_idx = 0;
             cJSON_ArrayForEach(irq, value) {
-                desc <<= 10;
                 if (cJSON_IsNull(irq)) {
-                    desc |= 0x3FF;
+                    desc |= 0x3FF << desc_idx;
                 } else if (cJSON_IsNumber(irq)) {
-                    desc |= ((u16)(irq->valueint)) & 0x3FF;
+                    desc |= (((u16)(irq->valueint)) & 0x3FF) << desc_idx;
                 } else {
                     fprintf(stderr, "Failed to parse IRQ value.\n");
                     status = 0;
                     goto PARSE_CAPS_END;
                 }
+                desc_idx += 10;
             }
             kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 12) | (0x07FF));
         } else if (!strcmp(type_str, "application_type")) {

--- a/src/elf2kip.c
+++ b/src/elf2kip.c
@@ -445,6 +445,10 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
             }
             desc = (allow_debug & 1) | ((force_debug & 1) << 1);
             kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 17) | (0xFFFF));
+        } else {
+            fprintf(stderr, "Error: unknown capability %s\n", type_str);
+            status = 0;
+            goto PARSE_CAPS_END;
         }
     }
     
@@ -452,6 +456,7 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
         kip_hdr->Capabilities[i] = 0xFFFFFFFF;
     }
     
+    status = 1;
     PARSE_CAPS_END:
     cJSON_Delete(npdm_json);
     return status;
@@ -479,7 +484,10 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
     
-    ParseKipConfiguration(json, &kip_hdr);
+    if (!ParseKipConfiguration(json, &kip_hdr)) {
+        fprintf(stderr, "Failed to parse kip configuration!\n");
+        return EXIT_FAILURE;
+    }
 
     size_t elf_len;
     uint8_t* elf = ReadEntireFile(argv[1], &elf_len);

--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -518,17 +518,18 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
                 goto NPDM_BUILD_END;
             }
             const cJSON *irq = NULL;
+            int desc_idx = 0;
             cJSON_ArrayForEach(irq, value) {
-                desc <<= 10;
                 if (cJSON_IsNull(irq)) {
-                    desc |= 0x3FF;
+                    desc |= 0x3FF << desc_idx;
                 } else if (cJSON_IsNumber(irq)) {
-                    desc |= ((u16)(irq->valueint)) & 0x3FF;
+                    desc |= (((u16)(irq->valueint)) & 0x3FF) << desc_idx;
                 } else {
                     fprintf(stderr, "Failed to parse IRQ value.\n");
                     status = 0;
                     goto NPDM_BUILD_END;
                 }
+                desc_idx += 10;
             }
             caps[cur_cap++] = (u32)((desc << 12) | (0x07FF));
         } else if (!strcmp(type_str, "application_type")) {


### PR DESCRIPTION
# Description

Currently, the NPDM-JSON format abuses duplicate keys where it should be using arrays instead. While cJSON supports this, most JSON parsers don't. This is causing issues for me currently when building linkle as serde-json (a deserializer for JSON in rust) doesn't support this. While I could probably fix that issue in serde-json, I think moving to a saner format using JSON arrays is also a good idea.

The main reason why this tool needs fixing, however, is that it makes it impossible to create tools that reason about NPDM-JSON generated by hactool. I've been meaning to create some tools that allows visualizing the interactions between all processes of the switch OS, using the NPDMs, and that is currently not possible without either manually parsing the raw NPDM, or using one of the few, rare JSON parsers that allow duplicate keys. This situation is annoying.

# Solution

After debating with SciresM a bit in the RS server, it was decided that `kernel_capabilities` should be changed to an object that takes two keys ("type" and "value"), and `service_access` would be split into two string arrays: `service_host` and `service_access`

```json
{
    "kernel_capabilities": [
        { "type": "irq_pair", "value": [1, 2] }
    ],
    "service_host": ["*"],
    "service_access": ["*"]
}
```

This PR deprecates duplicate-key style. It still allows parsing them though, to give some time for homebrew to migrate. It may get removed in a later PR.

 # Meta

Associated PR:

- hactool: https://github.com/SciresM/hactool/pull/54
- Atmosphere: https://github.com/Atmosphere-NX/Atmosphere/pull/215

I'll also mass-PR fixes to all open source homebrews.