### PR TITLE
Limited the name to 10 characters.

### DIFF
--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -79,7 +79,9 @@ typedef struct {
     u64 _0x10;
     u32 ProcessCategory;
     u32 MainThreadStackSize;
-    char Name[0x50];
+    char Name[0x10];
+    char ProductCode[0x10];
+    u8 _0x40[0x30];
     u32 Aci0Offset;
     u32 Aci0Size;
     u32 AcidOffset;
@@ -279,6 +281,12 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
         fprintf(stderr, "Failed to get title name (name field not present).\n");
         status = 0;
         goto NPDM_BUILD_END;
+    }
+
+    /* Parse product code. */
+    const cJSON *product_code = cJSON_GetObjectItemCaseSensitive(npdm_json, "product_code");
+    if (cJSON_IsString(product_code) && (product_code->valuestring != NULL)) {
+        strncpy(header.ProductCode, product_code->valuestring, sizeof(header.ProductCode) - 1);
     }
     
     /* Parse main_thread_stack_size. */

--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -282,12 +282,6 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
         status = 0;
         goto NPDM_BUILD_END;
     }
-
-    /* Parse product code. */
-    const cJSON *product_code = cJSON_GetObjectItemCaseSensitive(npdm_json, "product_code");
-    if (cJSON_IsString(product_code) && (product_code->valuestring != NULL)) {
-        strncpy(header.ProductCode, product_code->valuestring, sizeof(header.ProductCode) - 1);
-    }
     
     /* Parse main_thread_stack_size. */
     u64 stack_size = 0;


### PR DESCRIPTION
The name, product code and 30 bytes of reserved space was being used to store a extra long name. This change will make it so generate NPDM files conform to the standard on the wiki. (https://switchbrew.org/wiki/NPDM) ~~It also allows for version numbers to be store in the `ProductCode` field. I made it so the `product_code` field in the JSON was optional to not break compatibility with existing projects.~~