### PR TITLE
npdmtool: add compatibility for 8.0.0+ memory region capabilities

### DIFF
--- a/src/elf2kip.c
+++ b/src/elf2kip.c
@@ -440,7 +440,7 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
                 capability |= ((regions[i] & 0x3F) | ((is_ro[i] & 1) << 6)) << (11 + 7 * i);
             }
             kip_hdr->Capabilities[cur_cap++] = capability;
-        }  else if (!strcmp(type_str, "irq_pair")) {
+        } else if (!strcmp(type_str, "irq_pair")) {
             if (cur_cap + 1 > 0x20) {
                 fprintf(stderr, "Error: Too many capabilities!\n");
                 status = 0;


### PR DESCRIPTION
This adds the changes from #30 to npdmtool, intended in conjunction with supporting these capabilities as an atmosphere extension.