### PR TITLE
elf2kip/npdmtool: update json format to reflect modern OS.

### DIFF
--- a/src/elf2kip.c
+++ b/src/elf2kip.c
@@ -341,13 +341,17 @@ int ParseKipConfiguration(const char *json, KipHeader *kip_hdr) {
                 status = 0;
                 goto PARSE_CAPS_END;
             }
+
+            u8 real_highest_prio = (lowest_prio < highest_prio) ? lowest_prio : highest_prio;
+            u8 real_lowest_prio  = (lowest_prio > highest_prio) ? lowest_prio : highest_prio;
+
             desc = highest_cpu;
             desc <<= 8;
             desc |= lowest_cpu;
             desc <<= 6;
-            desc |= (lowest_prio & 0x3F);
+            desc |= (real_highest_prio & 0x3F);
             desc <<= 6;
-            desc |= (highest_prio & 0x3F);
+            desc |= (real_lowest_prio & 0x3F);
             kip_hdr->Capabilities[cur_cap++] = (u32)((desc << 4) | (0x0007));
         } else if (!strcmp(type_str, "syscalls")) {
             if (!cJSON_IsObject(value)) {

--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -363,6 +363,11 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
     }
     header.MmuFlags |= is_64_bit;
 
+    int optimize_memory_allocation; // optional
+    if (cJSON_GetBoolean(npdm_json, "optimize_memory_allocation", &optimize_memory_allocation)) {
+        header.MmuFlags |= ((optimize_memory_allocation & 1) << 4);
+    }
+
     int disable_device_address_space_merge; // optional
     if (cJSON_GetBoolean(npdm_json, "disable_device_address_space_merge", &disable_device_address_space_merge)) {
         header.MmuFlags |= ((disable_device_address_space_merge & 1) << 5);

--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -646,13 +646,17 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
                 status = 0;
                 goto NPDM_BUILD_END;
             }
+
+            u8 real_highest_prio = (lowest_prio < highest_prio) ? lowest_prio : highest_prio;
+            u8 real_lowest_prio  = (lowest_prio > highest_prio) ? lowest_prio : highest_prio;
+
             desc = highest_cpu;
             desc <<= 8;
             desc |= lowest_cpu;
             desc <<= 6;
-            desc |= (lowest_prio & 0x3F);
+            desc |= (real_highest_prio & 0x3F);
             desc <<= 6;
-            desc |= (highest_prio & 0x3F);
+            desc |= (real_lowest_prio & 0x3F);
             caps[cur_cap++] = (u32)((desc << 4) | (0x0007));
         } else if (!strcmp(type_str, "syscalls")) {
             if (!cJSON_IsObject(value)) {


### PR DESCRIPTION
Version field was incorrectly labeled "process_category". This is now supported (and defaults to 0 if not present on npdm, 1 if not present on kip). process_category is alias.

Support was added for mesosphere large-address map extension (these bits are reserved in official OS).

Support was added for specifying the signature key generation, which determines modulus used to verify ACID.

Support was added for system call capabilities in range [0x80, 0xBF], which kernel allows since 11.0.0.

"title_id" (and min/max) were renamed to program_id. If program_id not present, title_id used as alias.