### PR TITLE
nxlink: add option to override netloader target port

### DIFF
--- a/src/nxlink.c
+++ b/src/nxlink.c
@@ -422,7 +422,7 @@ static void showHelp() {
 	puts("Usage: nxlink [options] nrofile\n");
 	puts("--help,    -h   Display this information");
 	puts("--address, -a   Hostname or IPv4 address of Switch");
-    puts("--port,    -z   Port of Switch netloader server");
+	puts("--port,    -z   Port of Switch netloader server");
 	puts("--retries, -r   number of times to ping before giving up");
 	puts("--path   , -p   set upload path for file");
 	puts("--args          args to send to nro");
@@ -489,7 +489,7 @@ int main(int argc, char **argv) {
 	char *address = NULL;
 	char *basepath = NULL;
 	char *finalpath = NULL;
-    char *port = NULL;
+	char *port = NULL;
 	char *endarg = NULL;
 	char *extra_args = NULL;
 	int retries = 10;
@@ -505,7 +505,7 @@ int main(int argc, char **argv) {
 			{"address", required_argument, 0,	'a'},
 			{"retries", required_argument, 0,	'r'},
 			{"path",    required_argument, 0,	'p'},
-            {"port",    required_argument, 0,   'z'},
+			{"port",    required_argument, 0,   'z'},
 			{"args",    required_argument, 0,  NRO_ARGS},
 			{"help",    no_argument,       0,	'h'},
 			{"server",  no_argument,       &server,  1 },
@@ -525,9 +525,9 @@ int main(int argc, char **argv) {
 		case 'a':
 			address = optarg;
 			break;
-        case 'z':
-            port = optarg;
-            break;
+		case 'z':
+			port = optarg;
+			break;
 		case 'r':
 			errno = 0;
 			retries = strtoul(optarg, &endarg, 0);
@@ -646,10 +646,10 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-    int srvPort = NETLOADER_SERVER_PORT;
-    if (port != NULL) {
-        srvPort = atoi(port);
-    }
+	int srvPort = NETLOADER_SERVER_PORT;
+	if (port != NULL) {
+	    srvPort = atoi(port);
+	}
 
 	int res = sendNROFile(nxaddr.s_addr,finalpath,filesize,fh,srvPort);
 

--- a/src/nxlink.c
+++ b/src/nxlink.c
@@ -505,7 +505,7 @@ int main(int argc, char **argv) {
 			{"address", required_argument, 0,	'a'},
 			{"retries", required_argument, 0,	'r'},
 			{"path",    required_argument, 0,	'p'},
-			{"port",    required_argument, 0,   'z'},
+			{"port",    required_argument, 0,	'z'},
 			{"args",    required_argument, 0,  NRO_ARGS},
 			{"help",    no_argument,       0,	'h'},
 			{"server",  no_argument,       &server,  1 },


### PR DESCRIPTION
This PR adds an additional command line argument to override `NETLOADER_SERVER_PORT` via `--port [port]` or `-z [port]`.

Note: `-p` is already used for path, so I arbitrarily chose `-z` as the single letter flag for port.

Use-case: I have a remote server configured for Switch homebrew development which is used by multiple people. We use SSH tunnelling to forward the nxlink port to our Switch/emulator on local network, however only one person can do this at a time if we are limited to the default port. By allowing to override the port, we can choose any remote port for the SSH tunnel allowing multiple users to use nxlink simultaneously.

I know this use-case is niche considering there is no way to configure the netloader port in hbmenu by itself, so I understand if this PR is closed as out-of-scope.