### PR TITLE
npdmtool: Correct behavior when building npdm jsons without `force_debug_prod`

### DIFF
--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -838,7 +838,7 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
                 status = 0;
                 goto NPDM_BUILD_END;
             }
-            if (!cJSON_GetBoolean(value, "force_debug_prod", &force_debug_prod)) {
+            if (!cJSON_GetBooleanOptional(value, "force_debug_prod", &force_debug_prod)) {
                 status = 0;
                 goto NPDM_BUILD_END;
             }


### PR DESCRIPTION
#47 introduced a breaking change to every fork of the [exlaunch](https://github.com/shadowninja108/exlaunch) project.

Across GitHub, at least 40 public-facing modding projects that have been affected by the change. Some of these projects are abandoned and will not accept PRs to fix this, and currently fail to generate a complete build on the latest `switch-tools`. 
![image](https://github.com/user-attachments/assets/e07263b7-8f81-4dd5-bc02-a5f6404affc9)

Developers that didn't know about the 19.0.0 changes in my Discord have already updated their `switch-tools` package and have been met with a generic `Failed to parse descriptor json!` error.

This PR remedies the change by making `force_debug_prod` optional, supporting the older npdm jsons in exlaunch repositories.