### PR TITLE
npdmtool: don't error with missing debug flags, error with multiple set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT([switch-tools],[1.13.0],[https://github.com/switchbrew/switch-tools/issues])
+AC_INIT([switch-tools],[1.13.1],[https://github.com/switchbrew/switch-tools/issues])
 AC_CONFIG_SRCDIR([src/build_pfs0.c])
 
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -830,15 +830,11 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
             int allow_debug = 0;
             int force_debug = 0;
             int force_debug_prod = 0;
-            if (!cJSON_GetBoolean(value, "allow_debug", &allow_debug)) {
-                status = 0;
-                goto NPDM_BUILD_END;
-            }
-            if (!cJSON_GetBoolean(value, "force_debug", &force_debug)) {
-                status = 0;
-                goto NPDM_BUILD_END;
-            }
-            if (!cJSON_GetBoolean(value, "force_debug_prod", &force_debug_prod)) {
+            cJSON_GetBoolean(value, "allow_debug", &allow_debug);
+            cJSON_GetBoolean(value, "force_debug", &force_debug);
+            cJSON_GetBoolean(value, "force_debug_prod", &force_debug_prod);
+            if ( allow_debug + force_debug + force_debug_prod > 1 ) {
+                fprintf(stderr, "Only one debug flag can be set!\n");
                 status = 0;
                 goto NPDM_BUILD_END;
             }

--- a/src/npdmtool.c
+++ b/src/npdmtool.c
@@ -834,7 +834,7 @@ int CreateNpdm(const char *json, void **dst, u32 *dst_size) {
             cJSON_GetBoolean(value, "force_debug", &force_debug);
             cJSON_GetBoolean(value, "force_debug_prod", &force_debug_prod);
             if ( allow_debug + force_debug + force_debug_prod > 1 ) {
-                fprintf(stderr, "Only one debug flag can be set!\n");
+                fprintf(stderr, "Only one of allow_debug, force_debug, or force_debug_prod can be set!\n");
                 status = 0;
                 goto NPDM_BUILD_END;
             }


### PR DESCRIPTION
Thoughts on this @SciresM @fincs @yellows8 

I think we should maybe set these to sensible defaults & only error if more than one is set. Leaving an error with missing force_debug_prod doesn't seem useful to me and is obviously causing issues.